### PR TITLE
Fix spelling and grammar things

### DIFF
--- a/eg/index.html
+++ b/eg/index.html
@@ -179,12 +179,12 @@ my_embed_function(
     <p>
       <a href="http://oohembed.com/">Oohembed</a> is a very similar service. It even
       acts as a gateway to non-oEmbed enabled sites. The main limitation that I encountered
-      was its lack of guaranteed <code>html</code> field. Also, it is popular so it
+      was its lack of a guaranteed <code>html</code> field. Also, it is popular so it
       regularly goes over its usage limits.
     </p>
     <p>
       <a href="http://embed.ly/">embed.ly</a>. I have not tried this service, but it
-      lists support for hundreds of sites. Unfortunatly, you can not add your own providers,
+      lists support for hundreds of sites. Unfortunately, you can not add your own providers,
       so you are limited to what they support.
     </p>
 


### PR DESCRIPTION
Fix spelling and grammar things in the "Similar Sites" part of `eg/index.html`
