### PR TITLE
Add support for images behind Dropbox sharing links

### DIFF
--- a/lib/Noembed/Source/Dropbox.pm
+++ b/lib/Noembed/Source/Dropbox.pm
@@ -1,0 +1,18 @@
+package Noembed::Source::Dropbox;
+
+use parent 'Noembed::ImageSource';
+
+sub patterns { 'https?://www\.(dropbox\.com/s/.+\.(?:jpg|png|gif))' }
+sub provider_name { "Dropbox" }
+
+sub build_url {
+  my ($self, $req) = @_;
+  return "https://dl.".$req->captures->[0];
+}
+
+sub image_data {
+  my ($self, $body, $req) = @_;
+  return { src => "https://dl.".$req->captures->[0] };
+}
+
+1;


### PR DESCRIPTION
Dropbox sharing links are dumb.
