### PR TITLE
Move twitter to api 1.1

### DIFF
--- a/lib/Noembed/Source/Twitter.pm
+++ b/lib/Noembed/Source/Twitter.pm
@@ -10,7 +10,7 @@ use parent 'Noembed::Source';
 sub prepare_source {
   my $self = shift;
   $self->{name_re} = qr{(?:^|\W)(@[^\s:]+)};
-  $self->{tweet_api} = "http://api.twitter.com/1/statuses/show/%s.json?include_entities=true";
+  $self->{tweet_api} = "http://api.twitter.com/1.1/statuses/show/%s.json?include_entities=true";
   $self->{credentials} = read_credentials();
 }
 


### PR DESCRIPTION
the 1.1 API has much higher rate limits, according to @capotej
