### PR TITLE
Update Instagram regex to matche both .com and .am tlds

### DIFF
--- a/lib/Noembed/Source/Instagram.pm
+++ b/lib/Noembed/Source/Instagram.pm
@@ -18,7 +18,7 @@ sub image_data {
   $self->{scraper}->scrape($body);
 }
 
-sub patterns { 'https?://instagr\.am/p/.+' }
+sub patterns { 'https?://instagr(am\.com|\.am)/p/.+' }
 sub provider_name { "Instagram" }
 
 1;


### PR DESCRIPTION
This change updates the instagram pattern regex to catch both instagr.am and instagram.com URLs
