### PR TITLE
Disable providers that can't be initialized

### DIFF
--- a/lib/Noembed.pm
+++ b/lib/Noembed.pm
@@ -103,7 +103,11 @@ sub register_provider {
     return;
   }
 
-  my $provider = $class->new(render => $self->{render});
+  my $provider = eval { $class->new(render => $self->{render}) };
+  if ($@) {
+    warn "Could not initialize provider $class, disabling: $@";
+    return;
+  }
   push @{ $self->{providers} }, $provider;
   push @{ $self->{shorturls} }, map {qr{$_}} $provider->shorturls;
 }


### PR DESCRIPTION
So noembed can be run without amazon and twitter api keys.
