### PR TITLE
Added GIFUK (http://gifuk.com) as an oEmbed Provider

### DIFF
--- a/eg/demo.html
+++ b/eg/demo.html
@@ -197,6 +197,7 @@
               <li><a href="http://open.spotify.com/track/07FjCnZHF4XpHyMMFS20rl">http://open.spotify.com/track/07FjCnZHF4XpHyMMFS20rl</a></li>
               <li><a href="http://www.duffelblog.com/2014/01/military-juggalo/">http://www.duffelblog.com/2014/01/military-juggalo/</a></li>
               <li><a href="http://clyp.it/zhwuptos">http://clyp.it/zhwuptos</a></li>
+              <li><a href="http://gifuk.com/s/447b391f56d9b97c">http://gifuk.com/s/447b391f56d9b97c</a></li>
             </ul>
           </td>
           <td class="right">

--- a/eg/index.html
+++ b/eg/index.html
@@ -153,6 +153,7 @@ my_embed_function(
       <li>Clyp</li>
       <li>Flickr</li>
       <li>Funny or Die</li>
+      <li>GIFUK</li>
       <li>Hulu</li>
       <li>Qik</li>
       <li>Rdio</li>

--- a/lib/Noembed/Provider/GIFUK.pm
+++ b/lib/Noembed/Provider/GIFUK.pm
@@ -1,0 +1,9 @@
+package Noembed::Provider::GIFUK;
+
+use parent 'Noembed::oEmbedProvider';
+
+sub provider_name {"GIFUK"}
+sub patterns {'http://gifuk\.com/s/[0-9a-f]{16}'}
+sub oembed_url {'http://gifuk.com/oembed'}
+
+1;


### PR DESCRIPTION
GIFUK is a simple .gif sharing and hosting service that also converts your .gif files to .webm and .mp4
