### PR TITLE
Match www urls from Instagram

### DIFF
--- a/lib/Noembed/Provider/Instagram.pm
+++ b/lib/Noembed/Provider/Instagram.pm
@@ -18,7 +18,7 @@ sub image_data {
   $self->{scraper}->scrape($body);
 }
 
-sub patterns { 'https?://instagr(?:\.am|am\.com)/p/.+' }
+sub patterns { 'https?://(?:www\.)?instagr(?:\.am|am\.com)/p/.+' }
 sub provider_name { "Instagram" }
 
 1;


### PR DESCRIPTION
Urls like https://www.instagram.com/p/-X9cYdgfKr/ don't work, but are actually used in the wild. With the change noembed can handle thoses urls. This fixes #58 