### PR TITLE
update instagram provider endpoint schemes

### DIFF
--- a/share/providers.json
+++ b/share/providers.json
@@ -566,7 +566,11 @@
                     "http:\/\/instagram.com\/p\/*",
                     "http:\/\/instagr.am\/p\/*",
                     "https:\/\/instagram.com\/p\/*",
-                    "https:\/\/instagr.am\/p\/*"
+                    "https:\/\/instagr.am\/p\/*",
+                    "http:\/\/www.instagram.com\/p\/*",
+                    "http:\/\/www.instagr.am\/p\/*",
+                    "https:\/\/www.instagram.com\/p\/*",
+                    "https:\/\/www.instagr.am\/p\/*"
                 ],
                 "url": "http:\/\/api.instagram.com\/oembed",
                 "formats": [


### PR DESCRIPTION
Instagram's primary URLs now include a 'www' hostname in them
