### PR TITLE
Add Muki.io as provider

### DIFF
--- a/lib/Noembed/Provider/Muki.pm
+++ b/lib/Noembed/Provider/Muki.pm
@@ -1,0 +1,14 @@
+package Noembed::Provider::Muki;
+
+use parent 'Noembed::oEmbedProvider';
+
+sub provider_name { "Muki" }
+sub patterns { 'https?://muki\.io/(embed/)?(.+)' }
+sub options { qw/autoplay/ }
+
+sub build_url {
+  my ($self, $req) = @_;
+  return "https://muki.io/oembed/" . $req->captures->[1];
+}
+
+1;

--- a/share/demo/demo.html
+++ b/share/demo/demo.html
@@ -197,6 +197,7 @@
               <li><a href="http://open.spotify.com/track/07FjCnZHF4XpHyMMFS20rl">http://open.spotify.com/track/07FjCnZHF4XpHyMMFS20rl</a></li>
               <li><a href="http://www.duffelblog.com/2014/01/military-juggalo/">http://www.duffelblog.com/2014/01/military-juggalo/</a></li>
               <li><a href="http://clyp.it/zhwuptos">http://clyp.it/zhwuptos</a></li>
+              <li><a href="http://muki.io/list/best">http://muki.io/list/best</a></li>
             </ul>
           </td>
           <td class="right">

--- a/share/demo/index.html
+++ b/share/demo/index.html
@@ -110,7 +110,7 @@ my_embed_function(
     "type" : "rich",
     "title" : "Auto-Tune the News #8: dragons. geese. Michael Vick. (ft. T-Pain)"
   }
-) 
+)
 </pre>
     <p>
     <em>Note:</em> <a href="http://code.google.com/p/chromium/issues/detail?id=81637">Chrome now blocks insecure scripts from loading on secure sites</a>.
@@ -137,8 +137,9 @@ my_embed_function(
       <li>Gfycat</li>
       <li>GlobalGiving</li>
       <li>IMDB</li>
+      <li>Muki</li>
       <li>Monoprice</li>
-	  <li>Nooledge</li>
+	    <li>Nooledge</li>
       <li>Spotify</li>
       <li>TED</li>
       <li>The Onion</li>


### PR DESCRIPTION
This PR adds support for [Muki](http://muki.io), a WebAudio music player for MIDI, VGM and other sequenced chiptune formats. It already supports oembed so the implementation is pretty trivial. :)
