### PR TITLE
Fix Poll Daddy in providers.json

### DIFF
--- a/share/providers.json
+++ b/share/providers.json
@@ -767,9 +767,12 @@
         "endpoints": [
             {
                 "schemes": [
-                    "http:\/\/*.polldaddy.com\/s\/*",
-                    "http:\/\/*.polldaddy.com\/poll\/*",
-                    "http:\/\/*.polldaddy.com\/ratings\/*"
+                    "http:\/\/polldaddy.com\/s\/*",
+                    "http:\/\/polldaddy.com\/poll\/*",
+                    "http:\/\/polldaddy.com\/ratings\/*",
+                    "https:\/\/polldaddy.com\/s\/*",
+                    "https:\/\/polldaddy.com\/poll\/*",
+                    "https:\/\/polldaddy.com\/ratings\/*"
                 ],
                 "url": "http:\/\/polldaddy.com\/oembed\/"
             }


### PR DESCRIPTION
After some research I found, that this works fine:

    https://polldaddy.com/oembed/?url=http%3A//polldaddy.com/poll/9733846/

and that, this gives a 404:

    https://polldaddy.com/oembed/?url=http%3A//www.polldaddy.com/poll/9733846/