### PR TITLE
Specify HTTPS without &scheme

### DIFF
--- a/lib/Noembed/Provider/YouTube.pm
+++ b/lib/Noembed/Provider/YouTube.pm
@@ -15,11 +15,10 @@ sub options { qw/maxwidth maxheight autoplay/}
 
 sub build_url {
   my ($self, $req) = @_;
-  my $uri = URI->new("http://www.youtube.com/oembed/");
+  my $uri = URI->new("https://www.youtube.com/oembed/");
 
   my $id = $req->captures->[0];
   $uri->query_param("url", "http://www.youtube.com/watch?v=$id");
-  $uri->query_param("scheme", "https");
 
   return $uri;
 }


### PR DESCRIPTION
Fix for #115 

Explicitly use HTTPS to avoid `{ "error": { "code": 403, "message": "SSL is required to perform this operation.", "status": "PERMISSION_DENIED" } }`