### PR TITLE
Add x.com URL support and update Twitter provider endpoint

### DIFF
--- a/lib/Noembed/Provider/Twitter.pm
+++ b/lib/Noembed/Provider/Twitter.pm
@@ -2,16 +2,18 @@ package Noembed::Provider::Twitter;
 
 use parent 'Noembed::oEmbedProvider';
 
-sub patterns { 'https?://(?:www|mobile\.)?twitter\.com/(?:#!/)?([^/]+)/status(?:es)?/(\d+)' }
+# Matches both twitter.com and x.com post URLs (including mobile and hash-bang variants)
+sub patterns { 'https?://(?:www|mobile\.)?(?:twitter|x)\.com/(?:#!/)?([^/]+)/status(?:es)?/(\d+)' }
 
 sub build_url {
   my ($self, $req) = @_;
   my $captures = $req->captures;
+  # Normalize to twitter.com — publish.x.com/oembed does not reliably resolve x.com-domain URLs
   $req->url(sprintf "https://twitter.com/%s/status/%s", @$captures);
   $self->SUPER::build_url($req);
 }
 
-sub provider_name { "Twitter" }
-sub oembed_url { "https://publish.twitter.com/oembed" }
+sub provider_name { "X (formerly Twitter)" }
+sub oembed_url { "https://publish.x.com/oembed" }
 
 1;


### PR DESCRIPTION
  Twitter rebranded to X and the primary domain for post URLs is now `x.com`.                                                                                                                                                          
  The existing provider only matched `twitter.com` URLs and proxied to the legacy                                                                                                                                                      
  `publish.twitter.com` endpoint, so `x.com/...` post URLs returned no embed.                                                                                                                                                          
                                                                                                                                                                                                                                       
  ## Changes (`lib/Noembed/Provider/Twitter.pm`)                                                                                                                                                                                       
                                                                                                                                                                                                                                       
  - **Pattern**: extended to match both `twitter.com` and `x.com` post URLs                                                                                                                                                            
    (including `www.`, `mobile.`, and `#!/` hash-bang variants).                                                                                                                                                                       
  - **URL normalization**: `x.com` URLs are rewritten to `twitter.com` before                                                                                                                                                          
    calling the endpoint. `publish.x.com/oembed` does not reliably handle                                                                                                                                                              
    `x.com`-domain input — this is a documented platform bug with confirmed                                                                                                                                                            
    workarounds in WordPress core, Umbraco, Ghost, and Rocket.Chat.                                                                                                                                                                    
    - https://github.com/WordPress/gutenberg/issues/66980                                                                                                                                                                              
    - https://github.com/umbraco/Umbraco-CMS/issues/16645                                                                                                                                                                              
    - https://github.com/rocketchat/rocket.chat/issues/37429                                                                                                                                                                           
  - **Endpoint**: updated to the canonical `https://publish.x.com/oembed`                                                                                                                                                              
    per X developer documentation (https://docs.x.com/x-for-websites/oembed-api).                                                                                                                                                      
  - **Provider name**: updated to `X (formerly Twitter)`.                                                                                                                                                                              
                                                                                                                                                                                                                                       
  ## Testing                                                                                                                                                                                                                           
                                                                                                                                                                                                                                       
  ```bash                                                                                                                                                                                                                              
  # x.com — now matches                                                                                                                                                                                                                
  curl "http://localhost:5000/embed?url=https://x.com/<user>/status/<id>"                                                                                                                                                              
  # twitter.com — still works                                                                                                                                                                                                          
  curl "http://localhost:5000/embed?url=https://twitter.com/<user>/status/<id>"                                                                                                                                                        
  # mobile variants                                                                                                                                                                                                                    
  curl "http://localhost:5000/embed?url=https://mobile.x.com/<user>/status/<id>"                                                                                                                                                       
  curl "http://localhost:5000/embed?url=https://mobile.twitter.com/<user>/status/<id>"                                                                                                                                                 
                                                                                                                                                                                                                                       
  Expected: 200 JSON with provider_name: "X (formerly Twitter)" and an html                                                                                                                                                            
  field containing a <blockquote> embed.                                     